### PR TITLE
Consistent terminology in ABM dashboard

### DIFF
--- a/R/abm.R
+++ b/R/abm.R
@@ -745,13 +745,13 @@ abm_graph_copub <- function(df){
   df_copub_long<- df %>%
     select(interval, nonuniv_share, int_share) %>% 
     rename("Swedish Non-university" = nonuniv_share, "International" = int_share) %>% 
-    gather("Copublication", "value", -interval) %>% 
+    gather("Co-publication", "value", -interval) %>% 
     filter(!interval == "Total")
   
   ggplot(data = df_copub_long,
-         aes(x = interval, y = value, group = Copublication)) +
-    geom_line(aes(color = Copublication)) +
-    geom_point(aes(color = Copublication)) +
+         aes(x = interval, y = value, group = `Co-publication`)) +
+    geom_line(aes(color = `Co-publication`)) +
+    geom_point(aes(color = `Co-publication`)) +
     xlab(NULL) +
     ylab(NULL) +
     scale_y_continuous(labels = percent, limits = c(0, 1)) +

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -22,7 +22,7 @@ globalz <- "
     wos_coverage_Mean wos_coverage_NA Doc_id wos_bin
     WoS_coverage df_copub df_jcf indicator int_share nonuniv_share
     top10_share top20_share year measure target
-    from n_pad unit_long_en Copublication formatStyle styleEqual uc_from_orgid
+    from n_pad unit_long_en Co-publication formatStyle styleEqual uc_from_orgid
     abm_public_kth get_pt_ordning parent fullsort sort_order
 "
 

--- a/inst/extdata/abm.Rmd
+++ b/inst/extdata/abm.Rmd
@@ -8,7 +8,7 @@ output:
 params:
   unit_code: !r bibliomatrix:::abm_config()$default_unit
   is_employee: FALSE
-  use_package_data: FALSE
+  use_package_data: TRUE
   embed_data: FALSE
 ---
 
@@ -85,7 +85,7 @@ firstyear <- min(names(df_diva[yrfields]))
 lastyear <- max(names(df_diva[yrfields]))
 ```
 
-### **Total publications `r lastyear`<br>(fractional counts)**
+### **Publications in DiVA `r lastyear`<br>(fractional counts)**
 
 ```{r, fig.width = 3, fig.height = 2}
 if (nrow(df_diva) > 0){
@@ -122,7 +122,7 @@ last_interval <- ifelse(df_cf %>% filter(!is.na(P_frac)) %>% nrow() > 0,
                         "")
 ```
 
-### **[Publication indicators `r last_interval`](#citation-impact)** {.no-padding}
+### **[Citation impact `r last_interval`](#citation-impact)** {.no-padding}
 
 ```{r, fig.width = 3.5, fig.height = 2}
 if(df_cf %>% filter(!is.na(P_frac)) %>% nrow() > 0){
@@ -143,7 +143,7 @@ last_interval <- ifelse(df_jcf %>% filter(!is.na(P_frac)) %>% nrow() > 0,
                         nth(df_jcf$interval, -2),
                         "")
 ```
-### **[Journal indicators `r last_interval`](#journal-impact)**  {.no-padding}
+### **[Journal impact `r last_interval`](#journal-impact)**  {.no-padding}
 
 ```{r, fig.width = 3.5, fig.height = 2}
 if(df_jcf %>% filter(!is.na(P_frac)) %>% nrow() > 0){
@@ -162,7 +162,7 @@ if(df_jcf %>% filter(!is.na(P_frac)) %>% nrow() > 0){
 ```{r}
 last_interval <- nth(df_copub$interval, -2)
 ```
-### **[Copublication `r last_interval`](#co-publishing)** {.no-padding}
+### **[Co-publishing `r last_interval`](#co-publishing)** {.no-padding}
 ```{r, fig.width = 3, fig.height = 2}
 
 if(df_copub %>% filter(!is.na(P_full)) %>% nrow > 0){
@@ -437,15 +437,15 @@ Co-publishing
 Row
 ---------------------
 
-### **International and Swedish non-university copublications (full counts)**
+### **International and Swedish non-university co-publications (full counts)**
 
 ```{r}
 if(nrow(df_copub) > 0)
   DT::datatable(df_copub %>% rename("Publication years" = "interval",
                                    "Publications" = "P_full",
-                                   "Swedish non-university copublications" = "nonuniv_count",
+                                   "Swedish non-university co-publications" = "nonuniv_count",
                                    "Share Swedish non-university" = "nonuniv_share",
-                                   "International copublications" = "int_count",
+                                   "International co-publications" = "int_count",
                                    "Share international" = "int_share"),
                 rownames = FALSE,
                 extensions = "Buttons",
@@ -453,7 +453,7 @@ if(nrow(df_copub) > 0)
                   bPaginate = FALSE,
                   dom = 'Bt',
                   buttons = c("copy", "csv", "excel"),
-                  title = "ABM_copublications")
+                  title = "ABM_co-publications")
                 ) %>%
     formatPercentage(c(4,6), digits = 1) %>%
     abm_format_rows()
@@ -462,7 +462,7 @@ if(nrow(df_copub) > 0)
 Row
 -------
 
-### **International and Swedish non-university copublication**
+### **International and Swedish non-university co-publication**
 
 ```{r, fig.width=6, fig.height=4}
 if(df_copub %>% filter(!is.na(P_full)) %>% nrow > 0)


### PR DESCRIPTION
The labels on the first page are now consistent with their respective tab and co-publication is spelled with a dash everywhere.

Closes #58.