### PR TITLE
Include unit and date information in all downloads from ABM app.

### DIFF
--- a/inst/extdata/abm.Rmd
+++ b/inst/extdata/abm.Rmd
@@ -78,6 +78,12 @@ if(isTRUE(unit_level >= 0)){
 }
 
 
+unit_file_label <- ifelse(isTRUE(unit_level == 1),
+                          unit_info() %>% filter(unit_code == params$unit_code) %>% pull(unit_short),
+                          params$unit_code)
+
+current_date <- format(Sys.Date(), "%Y%m%d")
+
 
 ```
 
@@ -343,13 +349,9 @@ if (params$embed_data == TRUE) {
   
   #install.packages("openxlsx")
   library(openxlsx)
-  
-  # For schools, use unit_short for filename, otherwise use unit_code,
-  unitname <- ifelse(isTRUE(unit_level == 1),
-                     unit_info() %>% filter(unit_code == params$unit_code) %>% pull(unit_short),
-                     params$unit_code)
 
-  excel_file <- file.path(tempdir(), paste0("PublList_", unitname, ".xlsx"))
+  filename <- paste0("ABM_PubList_", unit_file_label, "_", current_date, ".xlsx")
+  excel_file <- file.path(tempdir(), filename)
   
   # Create excel workbook and define and format sheets
   export_excel<- createWorkbook()
@@ -411,6 +413,7 @@ if (nrow(df_diva) > 0) {
     "DiVA publication type" = "Publication_Type_DiVA",
     "Total" = "P_frac")
   
+  filename <- paste0("ABM_table1_", unit_file_label, "_", current_date)
   dt <- 
     DT::datatable(df,
       rownames = FALSE,
@@ -422,8 +425,10 @@ if (nrow(df_diva) > 0) {
         bPaginate = FALSE,
         pageLength = 100,
         dom = 'Bt',
-        buttons = list("copy", "csv", "excel"),
-        title = "ABM_publications")
+        buttons = list(list(extend = "copy"),
+                       list(extend = "csv", filename = filename),
+                       list(extend = "excel", filename = filename))
+        )
       ) %>%
     formatRound(2:9, digits = 1, mark = "") %>%
     formatPercentage("WoS coverage", digits = 1) %>%
@@ -520,6 +525,8 @@ df <- df_cit3y %>% rename(
 )
 
 if (nrow(df) > 0) {
+  filename <- paste0("ABM_table2_", unit_file_label, "_", current_date)
+
   DT::datatable(df,
     rownames = FALSE,
     extensions = "Buttons",
@@ -527,9 +534,11 @@ if (nrow(df) > 0) {
       ordering = FALSE,
       bPaginate = FALSE,
       dom = 'Bt',
-      buttons = c("copy", "csv", "excel"),
-      title = "ABM_citations")
-    ) %>% 
+      buttons = list(list(extend = "copy"),
+                     list(extend = "csv", filename = filename),
+                     list(extend = "excel", filename = filename))
+    )
+  ) %>% 
     formatRound(2:5, digits = 1, mark = "") %>%
     formatPercentage("Share Uncited", digits = 1) %>%
     abm_format_rows()
@@ -564,6 +573,7 @@ df <- df_cf %>% rename(
   "Share Top 10%" = "top10_share")
 
 if (nrow(df) > 0) {
+  filename <- paste0("ABM_table3_", unit_file_label, "_", current_date)
   DT::datatable(df,
     rownames = FALSE,
     extensions = "Buttons",
@@ -571,8 +581,10 @@ if (nrow(df) > 0) {
       ordering = FALSE,
       bPaginate = FALSE,
       dom = 'Bt',
-      buttons = c("copy", "csv", "excel"),
-      filename = "ABM_field_normalized_citations")
+      buttons = list(list(extend = "copy"),
+                     list(extend = "csv", filename = filename),
+                     list(extend = "excel", filename = filename))
+      )
     ) %>% 
     formatRound(c(2, 4), digits = 1, mark = "") %>% 
     formatRound(3, digits = 2, mark = "") %>%
@@ -708,6 +720,8 @@ df <- df_jcf %>% rename(
 )
 
 if (nrow(df) > 0) {
+  filename <- paste0("ABM_table4_", unit_file_label, "_", current_date)
+
   DT::datatable(df,
     rownames = FALSE,
     extensions = "Buttons",
@@ -715,9 +729,11 @@ if (nrow(df) > 0) {
       ordering = FALSE,
       bPaginate = FALSE,
       dom = 'Bt',
-      buttons = c("copy", "csv", "excel"),
-      title = "ABM_journal_impact")
-    ) %>% 
+      buttons = list(list(extend = "copy"),
+                     list(extend = "csv", filename = filename),
+                     list(extend = "excel", filename = filename))
+    )
+  ) %>% 
     formatRound(c(2, 4), digits = 1, mark = "") %>% 
     formatRound(3, digits = 2, mark = "") %>% 
     formatPercentage(5, digits = 1) %>%
@@ -825,6 +841,8 @@ df <- df_copub %>% rename(
   "Share international" = "int_share")
 
 if (nrow(df) > 0) {
+  filename <- paste0("ABM_table5_", unit_file_label, "_", current_date)
+  
   DT::datatable(df,
     rownames = FALSE,
     extensions = "Buttons",
@@ -832,8 +850,10 @@ if (nrow(df) > 0) {
       ordering = FALSE,
       bPaginate = FALSE,
       dom = 'Bt',
-      buttons = c("copy", "csv", "excel"),
-      title = "ABM_co-publications")
+      buttons = list(list(extend = "copy"),
+                     list(extend = "csv", filename = filename),
+                     list(extend = "excel", filename = filename))
+      )
     ) %>%
     formatPercentage(c(4,6), digits = 1) %>%
     abm_format_rows()

--- a/inst/extdata/abm.Rmd
+++ b/inst/extdata/abm.Rmd
@@ -84,6 +84,8 @@ unit_file_label <- ifelse(isTRUE(unit_level == 1),
 
 current_date <- format(Sys.Date(), "%Y%m%d")
 
+abm_unit_title<- paste0("ABM: ",unit_label)
+
 
 ```
 
@@ -425,9 +427,9 @@ if (nrow(df_diva) > 0) {
         bPaginate = FALSE,
         pageLength = 100,
         dom = 'Bt',
-        buttons = list(list(extend = "copy"),
-                       list(extend = "csv", filename = filename),
-                       list(extend = "excel", filename = filename))
+        buttons = list(list(extend = "copy", title=abm_unit_title),
+                       list(extend = "csv", filename = filename, title=abm_unit_title),
+                       list(extend = "excel", filename = filename, title=abm_unit_title))
         )
       ) %>%
     formatRound(2:9, digits = 1, mark = "") %>%
@@ -534,9 +536,9 @@ if (nrow(df) > 0) {
       ordering = FALSE,
       bPaginate = FALSE,
       dom = 'Bt',
-      buttons = list(list(extend = "copy"),
-                     list(extend = "csv", filename = filename),
-                     list(extend = "excel", filename = filename))
+      buttons = list(list(extend = "copy", title=abm_unit_title),
+                     list(extend = "csv", filename = filename, title=abm_unit_title),
+                     list(extend = "excel", filename = filename, title=abm_unit_title))
     )
   ) %>% 
     formatRound(2:5, digits = 1, mark = "") %>%
@@ -581,9 +583,9 @@ if (nrow(df) > 0) {
       ordering = FALSE,
       bPaginate = FALSE,
       dom = 'Bt',
-      buttons = list(list(extend = "copy"),
-                     list(extend = "csv", filename = filename),
-                     list(extend = "excel", filename = filename))
+      buttons = list(list(extend = "copy", title=abm_unit_title),
+                     list(extend = "csv", filename = filename, title=abm_unit_title),
+                     list(extend = "excel", filename = filename, title=abm_unit_title))
       )
     ) %>% 
     formatRound(c(2, 4), digits = 1, mark = "") %>% 
@@ -729,9 +731,9 @@ if (nrow(df) > 0) {
       ordering = FALSE,
       bPaginate = FALSE,
       dom = 'Bt',
-      buttons = list(list(extend = "copy"),
-                     list(extend = "csv", filename = filename),
-                     list(extend = "excel", filename = filename))
+      buttons = list(list(extend = "copy", title=abm_unit_title),
+                     list(extend = "csv", filename = filename, title=abm_unit_title),
+                     list(extend = "excel", filename = filename, title=abm_unit_title))
     )
   ) %>% 
     formatRound(c(2, 4), digits = 1, mark = "") %>% 
@@ -850,9 +852,9 @@ if (nrow(df) > 0) {
       ordering = FALSE,
       bPaginate = FALSE,
       dom = 'Bt',
-      buttons = list(list(extend = "copy"),
-                     list(extend = "csv", filename = filename),
-                     list(extend = "excel", filename = filename))
+      buttons = list(list(extend = "copy", title=abm_unit_title),
+                     list(extend = "csv", filename = filename, title=abm_unit_title),
+                     list(extend = "excel", filename = filename, title=abm_unit_title))
       )
     ) %>%
     formatPercentage(c(4,6), digits = 1) %>%

--- a/inst/shiny-apps/abm/ui.R
+++ b/inst/shiny-apps/abm/ui.R
@@ -14,6 +14,7 @@ dashboardPage(skin = "black",
       style = "padding-top:10px; padding-bottom:10px;"),
       class = "dropdown")),
    dashboardSidebar(
+     h4("Select unit:"),
      uiOutput("units")
   #   checkboxInput("use_prerendered", "Use pre-rendered content", value = TRUE)
    ),


### PR DESCRIPTION
The downloadable tables are named by number, ABM_table1 etc (except for the publication list that is named ABM_PubList_...).

A problem with the date stamps: the filenames are generated when the flexdashboard html is knitted, so it is not necessarily the download date. Maybe that is actually a good thing?

I guess we can also think a bit about whether we want to release this now, or add the other metadata stuff into this branch before we merge to master and release.