### PR TITLE
add sign-in and sign-out buttons to app

### DIFF
--- a/inst/shiny-apps/abm/server.R
+++ b/inst/shiny-apps/abm/server.R
@@ -73,7 +73,7 @@ server <- function(input, output, session) {
             orgs <- c(kthid(), orgs)
         
         shiny::selectInput(inputId = "unitid", label = "Select unit", 
-                           choices = orgs, selected = default_org_id(kthid()),
+                           choices = orgs, selected = 1, #default_org_id(kthid()),
                            multiple = FALSE, selectize = TRUE, width = "100%")
     })
     
@@ -86,6 +86,26 @@ server <- function(input, output, session) {
     
     is_employee <- function(id) id == kthid()
     
+    output$switcher <- renderUI({
+        if (!ABM_IS_PUBLIC) {
+            sidebarMenu(
+                id = "tabs",
+                menuItem("Switch to public app", href = ABM_URL_PUBLIC, 
+                         icon = icon("sign-out"), 
+                         badgeLabel = "Go", badgeColor = "blue")
+            )    
+        } else (
+            sidebarMenu(
+                id = "tabs",
+                menuItem(htmltools::HTML("Use your KTH account <br>to view your own data"), href = ABM_URL_PRIVATE, 
+                         icon = icon("sign-in"), 
+                         badgeLabel = "Go", badgeColor = "blue")
+            )    
+        )
+        
+    
+    })
+    
     output$login <- renderUI({
         if (!ABM_IS_PUBLIC) {
             out <- tags$li(class = "dropdown", 
@@ -93,8 +113,8 @@ server <- function(input, output, session) {
                 tags$li(class = "dropdown", 
                     tags$a(href = ABM_URL_PUBLIC,
                        class = "button button-primary button-sm",
-                       "Sign out", icon("sign-out"), " ... ",
-                       title = "Sign out and go to the public version of this application")
+                       "Switch to public app", icon("sign-out"), " ... ",
+                       title = "Switch to the public version of this application")
                 )
             )
         } else if (ABM_IS_PUBLIC == TRUE) {
@@ -103,8 +123,8 @@ server <- function(input, output, session) {
                 tags$li(class = "dropdown", 
                     tags$a(href = ABM_URL_PRIVATE, 
                         class = "button button-primary button-sm",
-                        "Sign in", icon("sign-in"), " ... ", img(src = "kth-logo.png", height = 30, width = 30),
-                        title = "Sign in here to view your own publications if you are a student or employed at KTH")
+                        "Use your KTH account", icon("sign-in"), " ... ", img(src = "kth-logo.png", height = 30, width = 30),
+                        title = "Switch to view your own publications if you are a KTH researcher")
                 )
             )            
         } else {

--- a/inst/shiny-apps/abm/server.R
+++ b/inst/shiny-apps/abm/server.R
@@ -14,9 +14,14 @@ library(purrr)
 # TODO config below could be a fcn
 
 #Sys.setenv("ABM_IS_PUBLIC" = "TRUE")
-#Sys.setenv("ABM_API" = "")
+#Sys.setenv("ABM_IS_PUBLIC" = "")
 
 ABM_IS_PUBLIC <- ifelse(Sys.getenv("ABM_IS_PUBLIC") != "", TRUE, FALSE)
+#Sys.setenv("ABM_API" = "")
+
+ABM_URL_PUBLIC <- ifelse(Sys.getenv("ABM_URL_PUBLIC") != "", Sys.getenv("ABM_URL_PUBLIC"), "https://kth.se/abm/public")
+ABM_URL_PRIVATE <- ifelse(Sys.getenv("ABM_URL_PRIVATE") != "", Sys.getenv("ABM_URL_PRIVATE"), "https://kth.se/abm")
+
 ABM_API <- Sys.getenv("ABM_API")
 
 if (ABM_API == "") ABM_API <- "http://localhost:8080"
@@ -67,7 +72,7 @@ server <- function(input, output, session) {
         if (!ABM_IS_PUBLIC)
             orgs <- c(kthid(), orgs)
         
-        shiny::selectInput(inputId = "unitid", label = NULL, 
+        shiny::selectInput(inputId = "unitid", label = "Select unit", 
                            choices = orgs, selected = default_org_id(kthid()),
                            multiple = FALSE, selectize = TRUE, width = "100%")
     })
@@ -80,6 +85,35 @@ server <- function(input, output, session) {
     }
     
     is_employee <- function(id) id == kthid()
+    
+    output$login <- renderUI({
+        if (!ABM_IS_PUBLIC) {
+            out <- tags$li(class = "dropdown", 
+                style = "padding-top:7px; padding-bottom:7px;",
+                tags$li(class = "dropdown", 
+                    tags$a(href = ABM_URL_PUBLIC,
+                       class = "button button-primary button-sm",
+                       "Sign out", icon("sign-out"), " ... ",
+                       title = "Sign out and go to the public version of this application")
+                )
+            )
+        } else if (ABM_IS_PUBLIC == TRUE) {
+            out <- tags$li(class = "dropdown", 
+                style = "padding-top:7px; padding-bottom:7px;",
+                tags$li(class = "dropdown", 
+                    tags$a(href = ABM_URL_PRIVATE, 
+                        class = "button button-primary button-sm",
+                        "Sign in", icon("sign-in"), " ... ", img(src = "kth-logo.png", height = 30, width = 30),
+                        title = "Sign in here to view your own publications if you are a student or employed at KTH")
+                )
+            )            
+        } else {
+            out <- ""
+        }
+        
+        cat(ABM_IS_PUBLIC, ": public state\n")
+        out
+    })
     
     output$frame <- renderUI({
         

--- a/inst/shiny-apps/abm/ui.R
+++ b/inst/shiny-apps/abm/ui.R
@@ -22,7 +22,8 @@ dashboardPage(skin = "black",
   ),
   dashboardSidebar(
     #tags$h4(textOutput("login")),
-    uiOutput("units")
+    uiOutput("units"),
+    uiOutput("switcher")
 #   checkboxInput("use_prerendered", "Use pre-rendered content", value = TRUE)
   ),
   dashboardBody(

--- a/inst/shiny-apps/abm/ui.R
+++ b/inst/shiny-apps/abm/ui.R
@@ -7,17 +7,24 @@ library(shinythemes)
 # TODO: workound various issue with getting the sizing to work properly
 
 dashboardPage(skin = "black",
-  dashboardHeader(title = "ABM KTH 2019", 
-    tags$li(a(href = 'https://intra.kth.se/bibliometri',
-#      img(src = "kth-logo.png", height = 30, width = 30),
-      title = "KTHB",
-      style = "padding-top:10px; padding-bottom:10px;"),
-      class = "dropdown")),
-   dashboardSidebar(
-     h4("Select unit:"),
-     uiOutput("units")
-  #   checkboxInput("use_prerendered", "Use pre-rendered content", value = TRUE)
-   ),
+  dashboardHeader(title = "ABM KTH 2019",
+    # tags$li(class = "dropdown",
+    #   #img(src = "kth-logo.png", height = 30, width = 30),
+    #   #style = "padding-top:10px; padding-bottom:10px;",
+    #   #class = "dropdown",
+    #   tags$li(class = "dropdown",
+    #     tags$a(href = 'https://kth.se/abm',
+    #       "Login", icon("sign-in"),
+    #       title = "Log in here if you are a student or employed at KTH" #,
+    #   ))
+    # )
+    uiOutput("login")#, inline = TRUE, container = tags$span)
+  ),
+  dashboardSidebar(
+    #tags$h4(textOutput("login")),
+    uiOutput("units")
+#   checkboxInput("use_prerendered", "Use pre-rendered content", value = TRUE)
+  ),
   dashboardBody(
     # this inline CSS is intented to retain indentations on iPhone (which seems )
     tags$head(tags$style(HTML('


### PR DESCRIPTION
An attempt to move context switching between the two app modes into the app. 

A sign-in link in the header if in public mode, else a sign-out that takes the user back to the public mode.